### PR TITLE
Pass seed value via CLI for deterministic results

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -22,9 +22,8 @@ static class Program
         Random random = new Random();
         foreach (XElement xelem in xdoc.Root.Elements("overlapping", "simpletiled"))
         {
-            Model model;
             string name = xelem.Get<string>("name");
-            Console.WriteLine($"< {name}");
+            Console.WriteLine($"Sample name: {name}");
 
             bool isOverlapping = xelem.Name == "overlapping";
             int size = xelem.Get("size", isOverlapping ? 48 : 24);
@@ -39,6 +38,7 @@ static class Program
                 _ => Model.Heuristic.Entropy
             };
 
+            Model model;
             if (isOverlapping)
             {
                 int N = xelem.Get("N", 3);
@@ -56,21 +56,29 @@ static class Program
                 model = new SimpleTiledModel(name, subset, width, height, periodic, blackBackground, heuristic);
             }
 
-            for (int i = 0; i < xelem.Get("screenshots", 2); i++)
+            var maxScreenshots = xelem.Get("screenshots", 2);
+            for (int i = 0; i < maxScreenshots; i++)
             {
-                for (int k = 0; k < 10; k++)
+                Console.WriteLine($" - Screenshot {i + 1}/{maxScreenshots}");
+                var maxAttempts = 10;
+                for (int k = 0; k < maxAttempts; k++)
                 {
-                    Console.Write("> ");
+                    Console.Write($"  - Attempt {k + 1}/{maxAttempts} --> ");
                     int seed = randomValueOverride ?? random.Next();
                     bool success = model.Run(seed, xelem.Get("limit", -1));
                     if (success)
                     {
-                        Console.WriteLine("DONE");
-                        model.Save($"{outputDirectoryName}/{name} {seed}.png");
+                        var filename = $"{outputDirectoryName}/{name} {seed}";
+                        var pngFilename = $"{filename}.png";
+                        model.Save(pngFilename);
+                        Console.Write($"DONE; wrote {pngFilename}");
                         if (model is SimpleTiledModel stmodel && xelem.Get("textOutput", false))
                         {
-                            File.WriteAllText($"{outputDirectoryName}/{name} {seed}.txt", stmodel.TextOutput());
+                            var textFilename = $"{filename}.txt";
+                            File.WriteAllText(textFilename, stmodel.TextOutput());
+                            Console.Write($" & {textFilename}");
                         }
+                        Console.WriteLine();
                         break;
                     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -9,8 +9,9 @@ static class Program
     static void Main()
     {
         Stopwatch sw = Stopwatch.StartNew();
-        var folder = System.IO.Directory.CreateDirectory("output");
-        foreach (var file in folder.GetFiles()) file.Delete();
+
+        const string outputDirectoryName = "output";
+        PrepareOutputDirectory(outputDirectoryName);
 
         Random random = new();
         XDocument xdoc = XDocument.Load("samples.xml");
@@ -56,9 +57,9 @@ static class Program
                     if (success)
                     {
                         Console.WriteLine("DONE");
-                        model.Save($"output/{name} {seed}.png");
+                        model.Save($"{outputDirectoryName}/{name} {seed}.png");
                         if (model is SimpleTiledModel stmodel && xelem.Get("textOutput", false))
-                            System.IO.File.WriteAllText($"output/{name} {seed}.txt", stmodel.TextOutput());
+                            System.IO.File.WriteAllText($"{outputDirectoryName}/{name} {seed}.txt", stmodel.TextOutput());
                         break;
                     }
                     else Console.WriteLine("CONTRADICTION");
@@ -67,5 +68,11 @@ static class Program
         }
 
         Console.WriteLine($"time = {sw.ElapsedMilliseconds}");
+    }
+
+    private static void PrepareOutputDirectory(string directoryName)
+    {
+        var directory = System.IO.Directory.CreateDirectory(directoryName);
+        foreach (var file in directory.GetFiles()) file.Delete();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -56,11 +56,11 @@ static class Program
                 model = new SimpleTiledModel(name, subset, width, height, periodic, blackBackground, heuristic);
             }
 
-            var maxScreenshots = xelem.Get("screenshots", 2);
+            var maxScreenshots = randomValueOverride.HasValue ? 1 : xelem.Get("screenshots", 2);
             for (int i = 0; i < maxScreenshots; i++)
             {
                 Console.WriteLine($" - Screenshot {i + 1}/{maxScreenshots}");
-                var maxAttempts = 10;
+                var maxAttempts = randomValueOverride.HasValue ? 1 : 10;
                 for (int k = 0; k < maxAttempts; k++)
                 {
                     Console.Write($"  - Attempt {k + 1}/{maxAttempts} --> ");

--- a/Program.cs
+++ b/Program.cs
@@ -64,25 +64,7 @@ static class Program
                 for (int k = 0; k < maxAttempts; k++)
                 {
                     Console.Write($"  - Attempt {k + 1}/{maxAttempts} --> ");
-                    int seed = randomValueOverride ?? random.Next();
-                    bool success = model.Run(seed, xelem.Get("limit", -1));
-                    if (success)
-                    {
-                        var filename = $"{outputDirectoryName}/{name} {seed}";
-                        var pngFilename = $"{filename}.png";
-                        model.Save(pngFilename);
-                        Console.Write($"DONE; wrote {pngFilename}");
-                        if (model is SimpleTiledModel stmodel && xelem.Get("textOutput", false))
-                        {
-                            var textFilename = $"{filename}.txt";
-                            File.WriteAllText(textFilename, stmodel.TextOutput());
-                            Console.Write($" & {textFilename}");
-                        }
-                        Console.WriteLine();
-                        break;
-                    }
-
-                    Console.WriteLine("CONTRADICTION");
+                    if (AttemptToGenerateModel(randomValueOverride, random, model, xelem, outputDirectoryName, name)) break;
                 }
             }
         }
@@ -94,6 +76,30 @@ static class Program
         {
             CalculateAndSaveHashes(outputDirectoryName, randomValueOverride.Value, elapsedMilliseconds);
         }
+    }
+
+    private static bool AttemptToGenerateModel(int? randomValueOverride, Random random, Model model, XElement xelem, string outputDirectoryName, string name)
+    {
+        int seed = randomValueOverride ?? random.Next();
+        bool success = model.Run(seed, xelem.Get("limit", -1));
+        if (success)
+        {
+            var filename = $"{outputDirectoryName}/{name} {seed}";
+            var pngFilename = $"{filename}.png";
+            model.Save(pngFilename);
+            Console.Write($"DONE; wrote {pngFilename}");
+            if (model is SimpleTiledModel stmodel && xelem.Get("textOutput", false))
+            {
+                var textFilename = $"{filename}.txt";
+                File.WriteAllText(textFilename, stmodel.TextOutput());
+                Console.Write($" & {textFilename}");
+            }
+            Console.WriteLine();
+            return true;
+        }
+
+        Console.WriteLine("CONTRADICTION");
+        return false;
     }
 
     private static int? GetFlagValue(string[] args, string flagName)

--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 static class Program
 {
-    static void Main(string[] args)
+    private static void Main(string[] args)
     {
         Stopwatch sw = Stopwatch.StartNew();
 
@@ -80,7 +80,7 @@ static class Program
         }
 
         var elapsedMilliseconds = sw.ElapsedMilliseconds;
-        Console.WriteLine($"time = {elapsedMilliseconds} for generating output");
+        Console.WriteLine($"time = {elapsedMilliseconds} ms for generating output");
 
         if (randomValueOverride is not null)
         {
@@ -102,7 +102,7 @@ static class Program
         return null;
     }
 
-    static void CalculateAndSaveHashes(string directoryPath, int randomValueOverride, long elapsedMilliseconds)
+    private static void CalculateAndSaveHashes(string directoryPath, int randomValueOverride, long elapsedMilliseconds)
     {
         if (!Directory.Exists(directoryPath))
         {
@@ -135,7 +135,7 @@ static class Program
         File.WriteAllText(outputFileName, sb.ToString());
     }
 
-    static string ComputeSha256Hash(string filePath)
+    private static string ComputeSha256Hash(string filePath)
     {
         using SHA256 sha256 = SHA256.Create();
         using FileStream fs = File.OpenRead(filePath);

--- a/Program.cs
+++ b/Program.cs
@@ -6,14 +6,23 @@ using System.Diagnostics;
 
 static class Program
 {
-    static void Main()
+    static void Main(string[] args)
     {
         Stopwatch sw = Stopwatch.StartNew();
 
         const string outputDirectoryName = "output";
         PrepareOutputDirectory(outputDirectoryName);
 
-        Random random = new();
+        Random random = new Random();
+        string randomValueOverrideFlag = "--randomValueOverride";
+        int randomValueOverrideIndex = Array.IndexOf(args, randomValueOverrideFlag);
+
+        int? randomValueOverride = null;
+        if (randomValueOverrideIndex >= 0 && randomValueOverrideIndex + 1 < args.Length && int.TryParse(args[randomValueOverrideIndex + 1], out int flagValue))
+        {
+            randomValueOverride = flagValue;
+        }
+
         XDocument xdoc = XDocument.Load("samples.xml");
 
         foreach (XElement xelem in xdoc.Root.Elements("overlapping", "simpletiled"))
@@ -52,7 +61,7 @@ static class Program
                 for (int k = 0; k < 10; k++)
                 {
                     Console.Write("> ");
-                    int seed = random.Next();
+                    int seed = randomValueOverride ?? random.Next();
                     bool success = model.Run(seed, xelem.Get("limit", -1));
                     if (success)
                     {

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WaveFunctionCollapse;
+
+public static class Utils
+{
+    public static int? GetFlagValue(string[] args, string flagName)
+    {
+        int flagNameIndex = Array.IndexOf(args, flagName);
+
+        if (flagNameIndex >= 0 &&
+            flagNameIndex + 1 < args.Length &&
+            int.TryParse(args[flagNameIndex + 1], out int flagValue))
+        {
+            return flagValue;
+        }
+
+        return null;
+    }
+
+    public static void PrepareOutputDirectory(string directoryName)
+    {
+        var directory = Directory.CreateDirectory(directoryName);
+        foreach (var file in directory.GetFiles()) file.Delete();
+    }
+
+    public static void CalculateAndSaveHashes(string directoryPath, int randomValueOverride, long elapsedMilliseconds)
+    {
+        if (!Directory.Exists(directoryPath))
+        {
+            Console.WriteLine("Directory does not exist.");
+            return;
+        }
+
+        string[] filePaths = Directory.GetFiles(directoryPath);
+        Array.Sort(filePaths);
+
+        StringBuilder sb = new StringBuilder();
+        foreach (string filePath in filePaths)
+        {
+            string hash = ComputeSha256Hash(filePath);
+            string fileName = Path.GetFileName(filePath);
+            Console.WriteLine($"{fileName}: {hash}");
+            sb.AppendLine($"{fileName}: {hash}");
+        }
+
+        string timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
+        string outputFileName = $"{timestamp}_{randomValueOverride}.txt";
+
+        sb.AppendLine();
+        sb.AppendLine($"Elapsed Milliseconds: {elapsedMilliseconds}");
+        sb.AppendLine($"Runtime Version: {Environment.Version}");
+        sb.AppendLine($"Operating System: {Environment.OSVersion}");
+        sb.AppendLine($"Processor Count: {Environment.ProcessorCount}");
+        sb.AppendLine($"Processor Architecture: {RuntimeInformation.ProcessArchitecture}");
+
+        File.WriteAllText(outputFileName, sb.ToString());
+    }
+
+    private static string ComputeSha256Hash(string filePath)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        using FileStream fs = File.OpenRead(filePath);
+        byte[] hashBytes = sha256.ComputeHash(fs);
+        return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+    }
+}

--- a/WaveFunctionCollapse.csproj
+++ b/WaveFunctionCollapse.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The intended purpose of this PR is to allow for the creation of golden master records for characterization testing in order to assist with future refactoring.

Notable changes:
- Can pass a flag via the CLI to override the random seed integer used to generate the model
   - e.g. `dotnet run Program.cs --randomValueOverride 1559`
- Creates a .txt file containing the name of each file generated in the output folder along with its SHA256 digest
- Improve console logging messages